### PR TITLE
Package data inclusion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include cellmap_flow/dashboard/templates/*.html
+include cellmap_flow/dashboard/static/css/*.css
+include cellmap_flow/dashboard/static/js/*.js
+include cellmap_flow/dashboard/static/img/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 exclude = ["ignore"]
 
+[tool.setuptools.package-data]
+"cellmap_flow.dashboard" = ["templates/*.html", "templates/_*.html", "static/css/*.css", "static/js/*.js", "static/img/*"]
+
 [project.scripts]
 cellmap_flow = "cellmap_flow.cli.cli:cli"
 cellmap_flow_server = "cellmap_flow.cli.server_cli:cli"


### PR DESCRIPTION
Previously, non-python files were not included in install, leading to the dashboard not being accessible

These changes configure the library such that the specified files are part of the install.