### PR TITLE
Add missing-dependency popup and one-click install for pipeline builder

### DIFF
--- a/cellmap_flow/dashboard/app.py
+++ b/cellmap_flow/dashboard/app.py
@@ -14,6 +14,7 @@ from cellmap_flow.dashboard.routes.pipeline import pipeline_bp
 from cellmap_flow.dashboard.routes.blockwise import blockwise_bp
 from cellmap_flow.dashboard.routes.bbx_generator import bbx_bp
 from cellmap_flow.dashboard.routes.finetune import finetune_bp
+from cellmap_flow.dashboard.routes.dependencies import dependencies_bp
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ app.register_blueprint(pipeline_bp)
 app.register_blueprint(blockwise_bp)
 app.register_blueprint(bbx_bp)
 app.register_blueprint(finetune_bp)
+app.register_blueprint(dependencies_bp)
 
 
 def create_and_run_app(neuroglancer_url=None, inference_servers=None):

--- a/cellmap_flow/dashboard/routes/dependencies.py
+++ b/cellmap_flow/dashboard/routes/dependencies.py
@@ -1,0 +1,52 @@
+import logging
+import sys
+import subprocess
+
+from flask import Blueprint, request, jsonify
+
+from cellmap_flow.utils.import_utils import INSTALLABLE_PACKAGES
+
+logger = logging.getLogger(__name__)
+
+dependencies_bp = Blueprint("dependencies", __name__)
+
+
+@dependencies_bp.route("/api/dependencies/install", methods=["POST"])
+def install_dependency():
+    """Install missing optional package(s), restricted to a fixed allow-list.
+
+    The client can only ask for packages by their import name; the actual pip
+    install spec always comes from INSTALLABLE_PACKAGES on the server, never
+    from the request body, since this dashboard has no authentication.
+    """
+    data = request.get_json() or {}
+    packages = data.get("packages", [])
+
+    if not packages:
+        return jsonify({"success": False, "error": "No packages specified"}), 400
+
+    unknown = [p for p in packages if p not in INSTALLABLE_PACKAGES]
+    if unknown:
+        logger.warning(f"Rejected install request for non-allow-listed package(s): {unknown}")
+        return jsonify(
+            {"success": False, "error": f"Not on install allow-list: {', '.join(unknown)}"}
+        ), 400
+
+    specs = [INSTALLABLE_PACKAGES[p] for p in packages]
+    logger.warning(f"Installing dependencies: {specs}")
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", *specs],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        return jsonify({"success": False, "error": "Install timed out after 5 minutes"}), 504
+
+    log = (result.stdout + result.stderr)[-4000:]
+    if result.returncode != 0:
+        logger.error(f"pip install failed for {specs}:\n{log}")
+
+    return jsonify({"success": result.returncode == 0, "log": log})

--- a/cellmap_flow/dashboard/routes/models.py
+++ b/cellmap_flow/dashboard/routes/models.py
@@ -4,6 +4,7 @@ from flask import Blueprint, request, jsonify
 
 from cellmap_flow.globals import g, SERVER_CONFIG_KEYS
 from cellmap_flow.models.run import update_run_models
+from cellmap_flow.utils.import_utils import MissingDependencyError
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,9 @@ def create_model_config():
             'model_name': model_config.name,
             'config_dict': model_config.to_dict()
         })
+    except MissingDependencyError as e:
+        logger.warning(f"Missing dependency creating model config: {e}")
+        return jsonify({'error': str(e), 'missing_packages': e.missing_packages}), 400
     except Exception as e:
         logger.error(f"Error creating model config: {str(e)}")
         return jsonify({'error': str(e)}), 400

--- a/cellmap_flow/dashboard/routes/pipeline.py
+++ b/cellmap_flow/dashboard/routes/pipeline.py
@@ -13,6 +13,7 @@ from cellmap_flow.norm.input_normalize import (
     get_normalizations,
 )
 from cellmap_flow.post.postprocessors import get_postprocessors_list, get_postprocessors
+from cellmap_flow.utils.import_utils import MissingDependencyError
 from cellmap_flow.utils.load_py import load_safe_config
 from cellmap_flow.utils.scale_pyramid import get_raw_layer
 from cellmap_flow.utils.web_utils import encode_to_str, ARGS_KEY
@@ -331,6 +332,9 @@ def apply_pipeline():
             "postprocessors_applied": len(g.postprocess),
         })
 
+    except MissingDependencyError as e:
+        logger.warning(f"Missing dependency applying pipeline: {e}")
+        return jsonify({"error": str(e), "missing_packages": e.missing_packages}), 400
     except Exception as e:
         logger.error(f"Error applying pipeline: {e}")
         return jsonify({"error": str(e)}), 500

--- a/cellmap_flow/dashboard/static/css/pipeline_builder.css
+++ b/cellmap_flow/dashboard/static/css/pipeline_builder.css
@@ -218,6 +218,19 @@
             opacity: 0.8;
         }
 
+        .library-item-unavailable {
+            cursor: pointer;
+            opacity: 0.6;
+            border-color: #d9822b;
+            border-style: dashed;
+        }
+
+        .library-item-unavailable:hover {
+            background: rgba(217, 130, 43, 0.15);
+            border-color: #d9822b;
+            color: inherit;
+        }
+
         /* Canvas */
         .canvas {
             flex: 1;

--- a/cellmap_flow/dashboard/templates/pipeline_builder_v2.html
+++ b/cellmap_flow/dashboard/templates/pipeline_builder_v2.html
@@ -236,8 +236,27 @@
         </div>
     </div>
 
+    <!-- Missing Dependency Modal -->
+    <div id="dependency-modal" class="modal" style="display: none;">
+        <div class="modal-content" style="width: 480px;">
+            <div class="modal-header">
+                <h2>⚠ Missing Dependency</h2>
+                <button class="modal-close-btn" onclick="closeDependencyModal()">✕</button>
+            </div>
+            <div class="modal-body">
+                <p id="dependency-modal-message"></p>
+                <pre id="dependency-modal-log" style="display: none; max-height: 200px; overflow: auto; background: rgba(0,0,0,0.3); padding: 8px; border-radius: 4px; font-size: 12px; white-space: pre-wrap;"></pre>
+            </div>
+            <div class="modal-footer">
+                <button class="action-btn" onclick="closeDependencyModal()">Cancel</button>
+                <button class="action-btn" style="background: var(--accent-green); color: white;"
+                        onclick="installMissingDependencies()" id="dependency-install-btn">⬇ Install</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Modal Overlay -->
-    <div id="modal-overlay" class="modal-overlay" style="display: none;" 
+    <div id="modal-overlay" class="modal-overlay" style="display: none;"
          onclick="if(event.target === this) closeOutputChannelsModal()"></div>
 
     <script>
@@ -593,13 +612,20 @@
             const postContainer = document.getElementById('postprocessors-items');
             postsArray.forEach(item => {
                 const name = typeof item === 'string' ? item : item.name;
+                const isAvailable = typeof item === 'string' ? true : item.available !== false;
                 const elem = document.createElement('div');
-                elem.className = 'library-item';
-                elem.textContent = name;
-                elem.draggable = true;
+                elem.className = isAvailable ? 'library-item' : 'library-item library-item-unavailable';
+                elem.textContent = isAvailable ? name : `⚠ ${name}`;
                 elem.dataset.type = 'postprocessor';
                 elem.dataset.name = name;
-                elem.addEventListener('dragstart', handleDragStart);
+                if (isAvailable) {
+                    elem.draggable = true;
+                    elem.addEventListener('dragstart', handleDragStart);
+                } else {
+                    elem.draggable = false;
+                    elem.title = `Missing: ${(item.missing_packages || []).join(', ')} — click to install`;
+                    elem.addEventListener('click', () => showDependencyModal(item.missing_packages || []));
+                }
                 postContainer.appendChild(elem);
             });
 
@@ -1355,6 +1381,58 @@
             }
         }
 
+        // ===== DEPENDENCY INSTALL =====
+        let pendingMissingPackages = [];
+
+        function showDependencyModal(missingPackages) {
+            pendingMissingPackages = missingPackages || [];
+            document.getElementById('dependency-modal-message').textContent = pendingMissingPackages.length
+                ? `This option requires the following package(s), which aren't installed on the server: ${pendingMissingPackages.join(', ')}.`
+                : 'This option has an unresolved dependency issue.';
+            const logEl = document.getElementById('dependency-modal-log');
+            logEl.style.display = 'none';
+            logEl.textContent = '';
+            const btn = document.getElementById('dependency-install-btn');
+            btn.disabled = false;
+            btn.textContent = '⬇ Install';
+            document.getElementById('modal-overlay').style.display = 'block';
+            document.getElementById('dependency-modal').style.display = 'block';
+        }
+
+        function closeDependencyModal() {
+            document.getElementById('modal-overlay').style.display = 'none';
+            document.getElementById('dependency-modal').style.display = 'none';
+        }
+
+        async function installMissingDependencies() {
+            const btn = document.getElementById('dependency-install-btn');
+            const logEl = document.getElementById('dependency-modal-log');
+            btn.disabled = true;
+            btn.textContent = 'Installing...';
+            try {
+                const response = await fetch('/api/dependencies/install', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ packages: pendingMissingPackages })
+                });
+                const result = await response.json();
+                if (result.success) {
+                    btn.textContent = '✓ Installed — reloading...';
+                    setTimeout(() => window.location.reload(), 800);
+                } else {
+                    btn.disabled = false;
+                    btn.textContent = '⬇ Install';
+                    logEl.style.display = 'block';
+                    logEl.textContent = result.error || result.log || 'Install failed.';
+                }
+            } catch (error) {
+                btn.disabled = false;
+                btn.textContent = '⬇ Install';
+                logEl.style.display = 'block';
+                logEl.textContent = String(error);
+            }
+        }
+
         // ===== MODEL CONFIG CREATION =====
         let availableModelConfigTypes = {};
 
@@ -1389,7 +1467,8 @@
             Object.entries(availableModelConfigTypes).forEach(([className, config]) => {
                 const option = document.createElement('option');
                 option.value = className;
-                option.textContent = `${config.display_name} - ${config.description}`;
+                const label = `${config.display_name} - ${config.description}`;
+                option.textContent = config.available === false ? `⚠ ${label} (requires install)` : label;
                 select.appendChild(option);
             });
         }
@@ -1397,15 +1476,29 @@
         function updateModelConfigForm(className) {
             const container = document.getElementById('model-config-form-container');
             const formDiv = document.getElementById('model-config-form');
-            
+
             if (!className) {
                 container.style.display = 'none';
                 return;
             }
-            
+
             const config = availableModelConfigTypes[className];
             formDiv.innerHTML = '';
-            
+
+            if (config.available === false) {
+                const banner = document.createElement('div');
+                banner.style.cssText = 'margin-bottom: 16px; padding: 10px; border: 1px solid #d9822b; border-radius: 4px; background: rgba(217, 130, 43, 0.1); display: flex; align-items: center; justify-content: space-between; gap: 12px;';
+                const text = document.createElement('span');
+                text.innerHTML = `<strong>⚠ Missing dependency:</strong> ${(config.missing_packages || []).join(', ')}`;
+                const installBtn = document.createElement('button');
+                installBtn.className = 'action-btn';
+                installBtn.textContent = '⬇ Install';
+                installBtn.onclick = () => showDependencyModal(config.missing_packages || []);
+                banner.appendChild(text);
+                banner.appendChild(installBtn);
+                formDiv.appendChild(banner);
+            }
+
             // Group parameters into required and optional
             const required = Object.entries(config.parameters).filter(([_, info]) => info.required);
             const optional = Object.entries(config.parameters).filter(([_, info]) => !info.required);
@@ -1513,10 +1606,14 @@
                 
                 if (!response.ok) {
                     const error = await response.json();
-                    alert(`Error: ${error.error}`);
+                    if (error.missing_packages && error.missing_packages.length) {
+                        showDependencyModal(error.missing_packages);
+                    } else {
+                        alert(`Error: ${error.error}`);
+                    }
                     return;
                 }
-                
+
                 const result = await response.json();
                 console.log('Model config created:', result);
                 
@@ -2110,6 +2207,10 @@
                 const result = await response.json();
                 if (!response.ok) {
                     console.error('Pipeline sync error:', result.error || 'Unknown error');
+                    const alreadyOpen = document.getElementById('dependency-modal').style.display === 'block';
+                    if (!alreadyOpen && result.missing_packages && result.missing_packages.length) {
+                        showDependencyModal(result.missing_packages);
+                    }
                 }
             } catch (err) {
                 console.error('Pipeline sync failed:', err.message);

--- a/cellmap_flow/models/model_registry.py
+++ b/cellmap_flow/models/model_registry.py
@@ -5,6 +5,7 @@ import os
 import inspect
 from typing import Dict, Any, List
 from huggingface_hub import list_models, hf_hub_download
+from cellmap_flow.utils.import_utils import get_missing_dependencies, MissingDependencyError
 from cellmap_flow.models.models_config import (
     ScriptModelConfig,
     DaCapoModelConfig,
@@ -127,11 +128,14 @@ def get_all_model_configs() -> Dict[str, Dict[str, Any]]:
             else:
                 param_info['input_type'] = 'text'
         
+        missing_packages = get_missing_dependencies(getattr(cls, 'REQUIRED_PACKAGES', []))
         registry[class_name] = {
             'display_name': display_name,
             'description': f'Create a {display_name} model configuration',
             'parameters': params,
             'class_name': class_name,
+            'available': len(missing_packages) == 0,
+            'missing_packages': missing_packages,
         }
     
     return registry
@@ -214,6 +218,9 @@ def instantiate_model_config(class_name: str, params: Dict[str, Any]) -> Any:
     
     try:
         return cls(**parsed_params)
+    except MissingDependencyError:
+        # Let this propagate as-is so callers can read `.missing_packages`.
+        raise
     except Exception as e:
         raise ValueError(f"Failed to instantiate {class_name}: {str(e)}")
 

--- a/cellmap_flow/models/models_config.py
+++ b/cellmap_flow/models/models_config.py
@@ -8,6 +8,7 @@ from funlib.geometry import Roi, Coordinate
 import numpy as np
 import torch
 from cellmap_flow.utils.serialize_config import Config
+from cellmap_flow.utils.import_utils import check_dependencies
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,11 @@ def _get_device():
 
 
 class ModelConfig:
+    # Import names (as passed to `check_dependencies`) a subclass needs beyond
+    # this module's hard dependencies. Overridden per subclass; used to report
+    # availability to the frontend via `get_all_model_configs()`.
+    REQUIRED_PACKAGES: list = []
+
     def __init__(self):
         self._config = None
 
@@ -241,9 +247,11 @@ class ScriptModelConfig(ModelConfig):
 class DaCapoModelConfig(ModelConfig):
 
     cli_name = "dacapo"
+    REQUIRED_PACKAGES = ["dacapo"]
 
     def __init__(self, run_name: str, iteration: int, name=None, scale=None):
         super().__init__()
+        check_dependencies(self.REQUIRED_PACKAGES)
         self.run_name = run_name
         self.iteration = iteration
         self.name = name
@@ -433,6 +441,7 @@ class FlyModelConfig(ModelConfig):
 class BioModelConfig(ModelConfig):
 
     cli_name = "bioimage"
+    REQUIRED_PACKAGES = ["bioimageio.core"]
 
     def __init__(
         self,
@@ -443,6 +452,7 @@ class BioModelConfig(ModelConfig):
         scale=None,
     ):
         super().__init__()
+        check_dependencies(self.REQUIRED_PACKAGES)
         self.model_name = model_name
         self.voxel_size = voxel_size
         self.name = name

--- a/cellmap_flow/post/postprocessors.py
+++ b/cellmap_flow/post/postprocessors.py
@@ -2,16 +2,32 @@ import logging
 import numpy as np
 import inspect
 import ast
-import neuroglancer
-import pymorton
 import threading
 from scipy.ndimage import label
-import mwatershed as mws
 from scipy.ndimage import measurements
-import fastremap
-from funlib.math import cantor_number
-import fastmorph
 from cellmap_flow.norm.input_normalize import SerializableInterface, deserialize_list
+from cellmap_flow.utils.import_utils import check_dependencies, get_missing_dependencies
+
+try:
+    import neuroglancer
+except ImportError:
+    neuroglancer = None
+try:
+    import pymorton
+except ImportError:
+    pymorton = None
+try:
+    import mwatershed as mws
+except ImportError:
+    mws = None
+try:
+    import fastremap
+except ImportError:
+    fastremap = None
+try:
+    import fastmorph
+except ImportError:
+    fastmorph = None
 
 postprocessing_lock = threading.Lock()
 
@@ -20,6 +36,17 @@ logger = logging.getLogger(__name__)
 
 class PostProcessor(SerializableInterface):
     """Base class for post-processing methods."""
+
+    # Import names (as passed to `check_dependencies`) a subclass needs beyond
+    # numpy/scipy. Overridden per subclass; used to gate instantiation and to
+    # report availability to the frontend via `get_postprocessors_list()`.
+    REQUIRED_PACKAGES: list[str] = []
+
+    def __new__(cls, *args, **kwargs):
+        # Checked in __new__ (not __init__) since subclasses don't call
+        # super().__init__() and this must gate construction regardless.
+        check_dependencies(cls.REQUIRED_PACKAGES)
+        return super().__new__(cls)
 
     def __init__(self):
         # Explicit empty __init__ so the GUI doesn't introspect *args/**kwargs
@@ -106,6 +133,8 @@ class LabelPostprocessor(PostProcessor):
 
 
 class MortonSegmentationRelabeling(PostProcessor):
+    REQUIRED_PACKAGES = ["pymorton"]
+
     def __init__(self, channel: int = 0):
         use_exact = "True"
         self.channel = int(channel)
@@ -145,6 +174,8 @@ class MortonSegmentationRelabeling(PostProcessor):
 
 
 class AffinityPostprocessor(PostProcessor):
+    REQUIRED_PACKAGES = ["mwatershed", "fastremap", "pymorton"]
+
     def __init__(
         self,
         bias: float = 0.0,
@@ -229,6 +260,8 @@ class AffinityPostprocessor(PostProcessor):
 
 class SimpleBlockwiseMerger(PostProcessor):
     # NOTE: Need to be careful since this can be called in parallel and some things may change size during loops etc.
+    REQUIRED_PACKAGES = ["neuroglancer", "fastmorph"]
+
     def __init__(
         self,
         channel: int = 0,
@@ -361,11 +394,14 @@ def get_postprocessors_list() -> list[dict]:
             if default_val is inspect._empty:
                 default_val = ""
             params[param_name] = default_val
+        missing_packages = get_missing_dependencies(post_cls.REQUIRED_PACKAGES)
         postprocessors.append(
             {
                 "class_name": post_cls.__name__,
                 "name": post_name,
                 "params": params,
+                "available": len(missing_packages) == 0,
+                "missing_packages": missing_packages,
             }
         )
     return postprocessors

--- a/cellmap_flow/utils/import_utils.py
+++ b/cellmap_flow/utils/import_utils.py
@@ -1,7 +1,20 @@
 import importlib
 
 
-def check_dependencies(dependencies):
+class MissingDependencyError(ImportError):
+    """Raised when one or more optional packages required by a feature aren't installed."""
+
+    def __init__(self, missing_packages):
+        self.missing_packages = list(missing_packages)
+        super().__init__(
+            f"Missing dependencies: {', '.join(self.missing_packages)}.\n"
+            "Install them from the dashboard's install prompt, or manually with:\n\n"
+            f"    pip install {' '.join(self.missing_packages)}"
+        )
+
+
+def get_missing_dependencies(dependencies):
+    """Return the subset of `dependencies` (import names) that can't be imported."""
     missing_packages = []
 
     for dep in dependencies:
@@ -10,9 +23,27 @@ def check_dependencies(dependencies):
         except ImportError:
             missing_packages.append(dep)
 
+    return missing_packages
+
+
+def check_dependencies(dependencies):
+    missing_packages = get_missing_dependencies(dependencies)
     if missing_packages:
-        raise ImportError(
-            f"Postprocessing dependencies not installed: {', '.join(missing_packages)}.\n"
-            "Please install them using:\n\n"
-            "    pip install cellmap-flow[postprocess]"
-        )
+        raise MissingDependencyError(missing_packages)
+
+
+# Allow-list of packages the dashboard's "install missing dependency" button may
+# install. Keys are import names (as used in `check_dependencies`); values are the
+# exact pip install spec. The install endpoint only accepts packages from this map -
+# never an arbitrary string from the client - since it runs on the server.
+INSTALLABLE_PACKAGES = {
+    "mwatershed": "mwatershed @ git+https://github.com/pattonw/mwatershed",
+    "funlib.math": "funlib.math @ git+https://github.com/funkelab/funlib.math.git",
+    "fastmorph": "fastmorph",
+    "fastremap": "fastremap",
+    "pymorton": "pymorton",
+    "edt": "edt",
+    "neuroglancer": "neuroglancer",
+    "dacapo": "dacapo-ml",
+    "bioimageio.core": "bioimageio.core[onnx,pytorch]==0.7.0",
+}

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -1,0 +1,35 @@
+import pytest
+
+from cellmap_flow.utils.import_utils import (
+    check_dependencies,
+    get_missing_dependencies,
+    MissingDependencyError,
+    INSTALLABLE_PACKAGES,
+)
+
+
+def test_get_missing_dependencies_reports_only_missing():
+    missing = get_missing_dependencies(["numpy", "definitely_not_a_real_package_xyz"])
+    assert missing == ["definitely_not_a_real_package_xyz"]
+
+
+def test_get_missing_dependencies_empty_when_all_present():
+    assert get_missing_dependencies(["numpy", "os"]) == []
+
+
+def test_check_dependencies_raises_missing_dependency_error():
+    with pytest.raises(MissingDependencyError) as exc_info:
+        check_dependencies(["definitely_not_a_real_package_xyz"])
+    assert exc_info.value.missing_packages == ["definitely_not_a_real_package_xyz"]
+
+
+def test_check_dependencies_passes_when_installed():
+    check_dependencies(["numpy"])  # should not raise
+
+
+def test_installable_packages_allow_list_only_contains_known_keys():
+    # Every entry should be a plain (import_name -> pip spec) mapping usable
+    # by the /api/dependencies/install allow-list check.
+    for import_name, pip_spec in INSTALLABLE_PACKAGES.items():
+        assert isinstance(import_name, str) and import_name
+        assert isinstance(pip_spec, str) and pip_spec


### PR DESCRIPTION
Postprocessors and model-config types (dacapo, bioimageio) each need different optional packages, and previously a single missing one crashed the whole dashboard at import time with no way to recover except SSH in and pip install manually. Now missing deps are detected without crashing, surfaced as an install prompt in the UI, and can be installed (from a fixed server-side allow-list only) with one click, reloading the page once done.